### PR TITLE
Fix team name in chart annotation

### DIFF
--- a/helm/cadvisor-app/Chart.yaml
+++ b/helm/cadvisor-app/Chart.yaml
@@ -11,6 +11,6 @@ sources:
 - https://github.com/google/cadvisor
 version: 0.44.0-gs1
 annotations:
-  application.giantswarm.io/team: Phoenix
+  application.giantswarm.io/team: phoenix
   branch: main
   commit: ""


### PR DESCRIPTION
The team name should be spelled lowercase, like it is in the GitHub slug.